### PR TITLE
Avoid duplicate standard quality tags

### DIFF
--- a/src/utils/quality.py
+++ b/src/utils/quality.py
@@ -4,12 +4,17 @@ def assemble_quality_tags(hf_service: bool = False,
                           hvof: bool = False,
                           water: bool = False,
                           stamicarbon: bool = False,
-                          extra=None):
-    sq_tags = ["[SQ58]", "[CORP-ENG-0115]"]
-    quality_lines = [
-        "SQ 58 - Controllo Visivo e Dimensionale delle Lavorazioni Meccaniche",
-        "CORP-ENG-0115 - General Surface Quality Requirements G1-1",
-    ]
+                          extra=None,
+                          include_standard: bool = True):
+    sq_tags = []
+    quality_lines = []
+
+    if include_standard:
+        sq_tags.extend(["[SQ58]", "[CORP-ENG-0115]"])
+        quality_lines.extend([
+            "SQ 58 - Controllo Visivo e Dimensionale delle Lavorazioni Meccaniche",
+            "CORP-ENG-0115 - General Surface Quality Requirements G1-1",
+        ])
     if hf_service:
         sq_tags.append("<SQ113>")
         quality_lines.append("SQ 113 - Material Requirements for Pumps in Hydrofluoric Acid Service (HF)")
@@ -56,15 +61,6 @@ def build_quality_tags(options):
     sq_tags = []
     quality_lines = []
 
-    if include_standard:
-        sq_tags.extend(["[SQ58]", "[CORP-ENG-0115]"])
-        quality_lines.extend(
-            [
-                "SQ 58 - Controllo Visivo e Dimensionale delle Lavorazioni Meccaniche",
-                "CORP-ENG-0115 - General Surface Quality Requirements G1-1",
-            ]
-        )
-
     tag_string, qual_descr = assemble_quality_tags(
         hf_service=options.get("hf_service", False),
         tmt_service=options.get("tmt_service", False),
@@ -73,6 +69,7 @@ def build_quality_tags(options):
         water=options.get("water", False),
         stamicarbon=options.get("stamicarbon", False),
         extra=options.get("extra"),
+        include_standard=include_standard,
     )
 
     if tag_string:

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.utils.quality import build_quality_tags
+
+
+def test_build_quality_tags_no_duplicates_with_standard():
+    """Standard quality tags should appear only once when included."""
+    options = {"hf_service": True, "include_standard": True}
+
+    tags_string, lines_string = build_quality_tags(options)
+
+    tags = tags_string.split()
+    lines = lines_string.split("\n")
+
+    assert tags.count("[SQ58]") == 1
+    assert tags.count("[CORP-ENG-0115]") == 1
+    assert len(tags) == len(set(tags))
+    assert len(lines) == len(set(lines))
+
+
+def test_build_quality_tags_skip_standard():
+    """Standard tags should be omitted when include_standard is False."""
+    options = {"hf_service": True, "include_standard": False}
+
+    tags_string, lines_string = build_quality_tags(options)
+
+    tags = tags_string.split()
+    lines = lines_string.split("\n") if lines_string else []
+
+    assert "[SQ58]" not in tags
+    assert "[CORP-ENG-0115]" not in tags
+    assert all("SQ 58 -" not in line for line in lines)


### PR DESCRIPTION
## Summary
- allow `assemble_quality_tags` to optionally include default tags
- have `build_quality_tags` delegate standard tag inclusion to `assemble_quality_tags`
- add tests ensuring quality tag lists have no duplicates and standard tags can be skipped

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4253fa65c83228ace9e700558a4bb