### PR TITLE
Remove lethal service checkbox for bearing bracket casting

### DIFF
--- a/Oracle_app.py
+++ b/Oracle_app.py
@@ -2119,7 +2119,7 @@ if selected_part in [
         material_note = st.text_input("Material Note", key="cast_mat_note")
 
         hf_service_casting = False
-        if selected_part != "Bearing housing casting":
+        if selected_part not in ["Bearing housing casting", "Bearing bracket casting"]:
             hf_service_casting = st.checkbox(
                 "Is it an hydrofluoric acid alkylation service (lethal)?",
                 key="cast_hf"


### PR DESCRIPTION
## Summary
- Exclude bearing bracket casting from lethal service checkbox prompt

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4716d3e1483228ef88bb272f05229