### PR TITLE
Limit CORP-ENG-0190 to bearing housing

### DIFF
--- a/Oracle_app.py
+++ b/Oracle_app.py
@@ -2344,11 +2344,6 @@ if selected_part in [
                 "SQ 58 - Controllo Visivo e Dimensionale delle Lavorazioni Meccaniche",
                 "CORP-ENG-0115 - General Surface Quality Requirements G1-1"
             ]
-            if selected_part == "Bearing housing casting":
-                qual_tags.append("[CORP-ENG-0190]")
-                quality_lines.append(
-                    "CORP-ENG-0190 - Coatings Specification for Bearings Housing and Frame Internal Oil Contacting Surfaces D16-1"
-                )
             if hf_service_casting:
                 qual_tags.append("<SQ113>")
                 quality_lines.append("SQ 113 - Material Requirements for Pumps in Hydrofluoric Acid Service (HF)")


### PR DESCRIPTION
## Summary
- remove CORP-ENG-0190 quality tag from Bearing housing casting
- keep CORP-ENG-0190 specification only for Bearing Housing output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5c59ed7bc8322a0ec7171a1064fe1