### PR TITLE
Add CORP-ENG-0115 quality to bearing housing

### DIFF
--- a/Oracle_app.py
+++ b/Oracle_app.py
@@ -2350,8 +2350,10 @@ elif selected_part == "Housing, Bearing":
             descr_parts = ["BEARING HOUSING"] + [
                 v for v in [brg_type, brg_size, note, materiale, material_note] if v
             ]
-            descr_parts.append("[CORP-ENG-0190]")
+            descr_parts.extend(["[SQ58]", "[CORP-ENG-0115]", "[CORP-ENG-0190]"])
             quality_lines = [
+                "SQ 58 - Controllo Visivo e Dimensionale delle Lavorazioni Meccaniche",
+                "CORP-ENG-0115 - General Surface Quality Requirements G1-1",
                 "CORP-ENG-0190 - Coatings Specification for Bearings Housing and Frame Internal Oil Contacting Surfaces D16-1",
             ]
             if brg_type in ["W", "W-TK"]:


### PR DESCRIPTION
## Summary
- include CORP-ENG-0115 default quality tag and description in bearing housing output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a861ed08508322a3dfe598f16c3954