### PR TITLE
Apply SQ95 to machining rather than castings

### DIFF
--- a/Oracle_app.py
+++ b/Oracle_app.py
@@ -35,7 +35,7 @@ st.selectbox = selectbox
 
 from src.utils.dataload import render_dataload_panel
 from src.utils.materials import get_fpd_code, select_material
-from src.utils.quality import build_quality_tags
+from src.utils.quality import build_quality_tags, CG_MATERIALS
 from src.utils.data import load_data
 from src.parts import casing, impeller
 from src.utils.constants import (
@@ -254,6 +254,8 @@ if selected_part == "Casing Cover, Pump":
                     "hvof": hvof,
                     "water": water,
                     "stamicarbon": stamicarbon,
+                    "material_prefix": mprefix,
+                    "material_name": mname,
                 }
             )
 
@@ -345,6 +347,8 @@ if selected_part == "Diffuser, Pump":
                     "hvof": hvof,
                     "water": water,
                     "stamicarbon": stamicarbon,
+                    "material_prefix": mprefix,
+                    "material_name": mname,
                 }
             )
 
@@ -435,6 +439,8 @@ if selected_part == "Balance Bushing, Pump":
                     "hvof": hvof,
                     "water": water,
                     "stamicarbon": stamicarbon,
+                    "material_prefix": mprefix,
+                    "material_name": mname,
                 }
             )
 
@@ -526,6 +532,8 @@ if selected_part == "Balance Drum, Pump":
                     "hvof": hvof,
                     "water": water,
                     "stamicarbon": stamicarbon,
+                    "material_prefix": mprefix,
+                    "material_name": mname,
                 }
             )
 
@@ -609,6 +617,8 @@ if selected_part == "Neck Bush, Pump":
                     "hvof": hvof,
                     "water": water,
                     "stamicarbon": stamicarbon,
+                    "material_prefix": mprefix,
+                    "material_name": mname,
                 }
             )
 
@@ -691,6 +701,8 @@ if selected_part == "Throat Bushing, Pump":
                     "hvof": hvof,
                     "water": water,
                     "stamicarbon": stamicarbon,
+                    "material_prefix": mprefix,
+                    "material_name": mname,
                 }
             )
 
@@ -774,6 +786,8 @@ if selected_part == "Nut, Impeller":
                     "hvof": hvof,
                     "water": water,
                     "stamicarbon": stamicarbon,
+                    "material_prefix": mprefix,
+                    "material_name": mname,
                 }
             )
 
@@ -859,6 +873,8 @@ if selected_part == "Nut, Shaft Sleeve":
                     "hvof": hvof,
                     "water": water,
                     "stamicarbon": stamicarbon,
+                    "material_prefix": mprefix,
+                    "material_name": mname,
                 }
             )
 
@@ -943,6 +959,8 @@ if selected_part == "Balance Disc, Pump":
                     "hvof": hvof,
                     "water": water,
                     "stamicarbon": stamicarbon,
+                    "material_prefix": mprefix,
+                    "material_name": mname,
                 }
             )
 
@@ -1960,6 +1978,8 @@ if selected_part == "Ring, Wear":
                 "hvof": hvof,
                 "stamicarbon": stamicarbon,
                 "extra": extra,
+                "material_prefix": mprefix,
+                "material_name": mname,
             })
 
             # Descrizione
@@ -2194,6 +2214,11 @@ if selected_part == "Shaft, Pump":
             if hf_service:
                 sq_tags.append("<SQ113>")
                 quality_lines.append("SQ 113 - Material Requirements for Pumps in Hydrofluoric Acid Service (HF)")
+            if (mprefix, mname) in CG_MATERIALS:
+                sq_tags.append("[SQ95]")
+                quality_lines.append(
+                    "SQ 95 - Ciclo di Lavorazione CG3M e CG8M (fuso AISI 317L e AISI 317)"
+                )
 
             tag_string = " ".join(sq_tags)
             quality    = "\n".join(quality_lines)
@@ -2277,6 +2302,8 @@ elif selected_part == "Shaft Sleeve, Pump":
                     "hvof": hvof,
                     "water": water,
                     "stamicarbon": stamicarbon,
+                    "material_prefix": mprefix,
+                    "material_name": mname,
                 }
             )
 
@@ -2388,6 +2415,11 @@ elif selected_part == "Housing, Bearing":
             if brg_type in ["W", "W-TK"]:
                 descr_parts.append("[SQ36]")
                 quality_lines.append("SQ 36 - HPX Bearing Housing: Requisiti di Qualità")
+            if (mprefix, mname) in CG_MATERIALS:
+                descr_parts.append("[SQ95]")
+                quality_lines.append(
+                    "SQ 95 - Ciclo di Lavorazione CG3M e CG8M (fuso AISI 317L e AISI 317)"
+                )
             quality = "\n".join(quality_lines)
             descr = "*" + " - ".join(descr_parts)
 
@@ -2467,6 +2499,8 @@ elif selected_part == "Baseplate, Pump":
             erp2 = "18_FOUNDATION_PLATE"
             to_supplier = sourcing
 
+            needs_sq95 = (mat_prefix, mat_name) in CG_MATERIALS
+
             descr_parts = [
                 f"*{ident}",
                 f"{model}-{size}",
@@ -2478,14 +2512,19 @@ elif selected_part == "Baseplate, Pump":
                 "[SQ53]",
                 "[CORP-ENG-0234]"
             ]
-       
-   
+            if needs_sq95:
+                descr_parts.append("[SQ95]")
+
             descr = " ".join([d for d in descr_parts if d])
 
             quality = [
                 "SQ 53 - HORIZONTAL PUMP BASEPLATES CHECKING PROCEDURE",
                 "CORP-ENG-0234 - Procedure for Baseplate Inspection J4-11"
             ]
+            if needs_sq95:
+                quality.append(
+                    "SQ 95 - Ciclo di Lavorazione CG3M e CG8M (fuso AISI 317L e AISI 317)"
+                )
         
 
             st.session_state["output_data"] = {
@@ -3023,17 +3062,6 @@ if selected_part in [
                     "CORP-ENG-0523 - As-Cast Surface Finish and Cleaning Requirements for Hydraulic Castings",
                     "CORP-ENG-0090 - Procurement and Cleaning Requirement for Hydraulic Castings - API, Vertical, Submersible, and Specialty Pumps P-5"
                 ])
-
-            cg_materials = {
-                ("A351_","CG3M"),("A351_","CG8M"),("A743_","CG3M"),("A743_","CG8M"),
-                ("A351_","CG8M + HVOF TUNGS. CARBIDE 86-10-4 (WC-Co-Cr) OVERLAY"),
-                ("A351_","CG3M + HVOF TUNGS. CARBIDE 86-10-4 (WC-Co-Cr) OVERLAY + PTA STELLITE 6 OVERLAY"),
-                ("A743_","CG8M + PTA STELLITE 12 OVERLAY"),("A743_","CG3M + PTA STELLITE 6 OVERLAY"),
-                ("A743_","CG3M + DLD WC-Ni 60-40"),("A744_","CG3M")
-            }
-            if (prefix, name) in cg_materials:
-                qual_tags.append("[SQ95]")
-                quality_lines.append("SQ 95 - Ciclo di Lavorazione CG3M e CG8M (fuso AISI 317L e AISI 317)")
 
             quality_field = "\n".join(quality_lines)
             description   = ", ".join(parts) + " " + " ".join(qual_tags)

--- a/src/parts/casing.py
+++ b/src/parts/casing.py
@@ -46,7 +46,14 @@ def render(size_df, features_df, materials_df, material_types):
 
         if st.button("Generate Output", key="casing_gen"):
             tag_string, quality = assemble_quality_tags(
-                hf_service, tmt_service, overlay, hvof, water, stamicarbon
+                hf_service,
+                tmt_service,
+                overlay,
+                hvof,
+                water,
+                stamicarbon,
+                mat_prefix=mprefix,
+                mat_name=mname,
             )
             descr_parts = ["CASING, PUMP"]
             for val in [model, size, feature_1, feature_2, note, materiale, material_note]:

--- a/src/parts/impeller.py
+++ b/src/parts/impeller.py
@@ -38,7 +38,15 @@ def render(size_df, features_df, materials_df, material_types):
             if mprefix == "A747_" and mname == "Tp. CB7Cu-1 (H1150 DBL)":
                 extra.append(("[DE2980.001]", "DE2980.001 - Progettazione e Produzione giranti in 17-4 PH"))
             tag_string, quality = assemble_quality_tags(
-                hf_service, tmt_service, overlay, hvof, water, stamicarbon, extra
+                hf_service,
+                tmt_service,
+                overlay,
+                hvof,
+                water,
+                stamicarbon,
+                extra=extra,
+                mat_prefix=mprefix,
+                mat_name=mname,
             )
             descr_parts = ["IMPELLER, PUMP"]
             for val in [model, size, feature_1, note, materiale, material_note]:

--- a/src/utils/quality.py
+++ b/src/utils/quality.py
@@ -1,11 +1,35 @@
-def assemble_quality_tags(hf_service: bool = False,
-                          tmt_service: bool = False,
-                          overlay: bool = False,
-                          hvof: bool = False,
-                          water: bool = False,
-                          stamicarbon: bool = False,
-                          extra=None,
-                          include_standard: bool = True):
+# Materials requiring SQ95 machining cycle
+from typing import Optional
+
+CG_MATERIALS = {
+    ("A351_", "CG3M"),
+    ("A351_", "CG8M"),
+    ("A743_", "CG3M"),
+    ("A743_", "CG8M"),
+    ("A351_", "CG8M + HVOF TUNGS. CARBIDE 86-10-4 (WC-Co-Cr) OVERLAY"),
+    (
+        "A351_",
+        "CG3M + HVOF TUNGS. CARBIDE 86-10-4 (WC-Co-Cr) OVERLAY + PTA STELLITE 6 OVERLAY",
+    ),
+    ("A743_", "CG8M + PTA STELLITE 12 OVERLAY"),
+    ("A743_", "CG3M + PTA STELLITE 6 OVERLAY"),
+    ("A743_", "CG3M + DLD WC-Ni 60-40"),
+    ("A744_", "CG3M"),
+}
+
+
+def assemble_quality_tags(
+    hf_service: bool = False,
+    tmt_service: bool = False,
+    overlay: bool = False,
+    hvof: bool = False,
+    water: bool = False,
+    stamicarbon: bool = False,
+    extra=None,
+    include_standard: bool = True,
+    mat_prefix: Optional[str] = None,
+    mat_name: Optional[str] = None,
+):
     sq_tags = []
     quality_lines = []
 
@@ -41,6 +65,11 @@ def assemble_quality_tags(hf_service: bool = False,
         for tag, line in extra:
             sq_tags.append(tag)
             quality_lines.append(line)
+    if mat_prefix and mat_name and (mat_prefix, mat_name) in CG_MATERIALS:
+        sq_tags.append("[SQ95]")
+        quality_lines.append(
+            "SQ 95 - Ciclo di Lavorazione CG3M e CG8M (fuso AISI 317L e AISI 317)"
+        )
     return " ".join(sq_tags), "\n".join(quality_lines)
 
 
@@ -70,6 +99,8 @@ def build_quality_tags(options):
         stamicarbon=options.get("stamicarbon", False),
         extra=options.get("extra"),
         include_standard=include_standard,
+        mat_prefix=options.get("material_prefix"),
+        mat_name=options.get("material_name"),
     )
 
     if tag_string:

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -33,3 +33,15 @@ def test_build_quality_tags_skip_standard():
     assert "[SQ58]" not in tags
     assert "[CORP-ENG-0115]" not in tags
     assert all("SQ 58 -" not in line for line in lines)
+
+
+def test_build_quality_tags_sq95_for_cg_materials():
+    """SQ95 should be added for CG3M/CG8M materials."""
+    options = {
+        "material_prefix": "A351_",
+        "material_name": "CG3M",
+        "include_standard": False,
+    }
+    tags_string, lines_string = build_quality_tags(options)
+    assert "[SQ95]" in tags_string.split()
+    assert "SQ 95 -" in lines_string


### PR DESCRIPTION
## Summary
- add material-based SQ95 logic in quality utilities
- attach SQ95 tag to machined parts instead of castings
- extend tests for SQ95 handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac4df64b4483228076fe56d857bc07