### PR TITLE
Remove SQ121 tag from machining

### DIFF
--- a/src/utils/quality.py
+++ b/src/utils/quality.py
@@ -123,11 +123,6 @@ def assemble_quality_tags(
         quality_lines.append(
             "SQ 95 - Ciclo di Lavorazione CG3M e CG8M (fuso AISI 317L e AISI 317)"
         )
-    if mat_name and mat_name in SQ121_MATERIALS:
-        sq_tags.append("[SQ121]")
-        quality_lines.append(
-            "SQ 121 - Cleaning, Descaling and Passivation of Stainless Steel Components"
-        )
     return " ".join(sq_tags), "\n".join(quality_lines)
 
 

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -47,9 +47,9 @@ def test_build_quality_tags_sq95_for_cg_materials():
     assert "SQ 95 -" in lines_string
 
 
-def test_build_quality_tags_sq121_for_materials():
-    """SQ121 should be added for specific stainless steel materials."""
+def test_build_quality_tags_no_sq121_for_materials():
+    """SQ121 should not be added for machining even for stainless steel materials."""
     options = {"material_name": "CF3M", "include_standard": False}
     tags_string, lines_string = build_quality_tags(options)
-    assert "[SQ121]" in tags_string.split()
-    assert "SQ 121 -" in lines_string
+    assert "[SQ121]" not in tags_string.split()
+    assert "SQ 121 -" not in lines_string


### PR DESCRIPTION
## Summary
- prevent SQ121 quality tag from being added during machining tag assembly
- adjust tests to confirm SQ121 is excluded from machining materials

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac7abbe3a88322bc7139711a778b5d