### PR TITLE
Handle missing casting code column gracefully

### DIFF
--- a/Oracle_app.py
+++ b/Oracle_app.py
@@ -34,7 +34,7 @@ def selectbox(label, options, *args, **kwargs):
 st.selectbox = selectbox
 
 from src.utils.dataload import render_dataload_panel
-from src.utils.materials import get_fpd_code, select_material
+from src.utils.materials import get_fpd_code, select_material, get_casting_code
 from src.utils.quality import build_quality_tags, CG_MATERIALS, SQ121_MATERIALS
 from src.utils.data import load_data
 from src.parts import casing, impeller
@@ -3005,7 +3005,7 @@ if selected_part in [
                 (materials_df["Prefix"] == prefix) &
                 (materials_df["Name"] == name)
             ]
-            casting_code      = dfm["Casting code"].iloc[0][-2:] if not dfm.empty else "XX"
+            casting_code      = get_casting_code(dfm)
             fpd_material_code = dfm["FPD Code"].iloc[0]       if not dfm.empty else "NA"
             item_number       = "7" + casting_code
             pattern_parts     = [m for m in [mod1, mod2, mod3, mod4, mod5] if m.strip()]

--- a/src/utils/materials.py
+++ b/src/utils/materials.py
@@ -97,3 +97,29 @@ def get_fpd_code(materials_df: pd.DataFrame, mat_type, mat_prefix, mat_name):
     if not row.empty and "FPD Code" in row.columns:
         return row.iloc[0]["FPD Code"]
     return "NOT AVAILABLE"
+
+
+def get_casting_code(dfm: pd.DataFrame) -> str:
+    """Extract the last two characters of the casting code.
+
+    Parameters
+    ----------
+    dfm : pandas.DataFrame
+        DataFrame potentially containing a ``Casting code`` column.
+
+    Returns
+    -------
+    str
+        The last two characters of the ``Casting code`` value in the first row
+        of ``dfm``.  If the dataframe is empty, the column is missing or the
+        value is null, the default ``"XX"`` is returned.
+    """
+
+    if dfm.empty or "Casting code" not in dfm.columns:
+        return "XX"
+
+    value = dfm.iloc[0].get("Casting code")
+    if pd.isna(value):
+        return "XX"
+
+    return str(value)[-2:]

--- a/tests/test_casting_code.py
+++ b/tests/test_casting_code.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+import sys
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.utils.materials import get_casting_code
+
+def test_get_casting_code_missing_column():
+    df = pd.DataFrame({"FPD Code": ["123"]})
+    assert get_casting_code(df) == "XX"
+
+def test_get_casting_code_present():
+    df = pd.DataFrame({"Casting code": ["AB12"]})
+    assert get_casting_code(df) == "12"
+
+def test_get_casting_code_nan_value():
+    df = pd.DataFrame({"Casting code": [pd.NA]})
+    assert get_casting_code(df) == "XX"


### PR DESCRIPTION
## Summary
- Add `get_casting_code` utility to safely extract casting codes with fallbacks
- Use the new helper in `Oracle_app.py` and import it
- Cover edge cases with unit tests for casting code extraction

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac7c0995d4832287a4ab38f69ee7c7